### PR TITLE
Fix possible build error Xcode > 12

### DIFF
--- a/RNChannelIO.podspec
+++ b/RNChannelIO.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
   
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "ChannelIOSDK"
 end


### PR DESCRIPTION
`podspec` 에 정의된 dependency 중, `React-Core` 누락으로 인해 Xcode > 12 에서 `use_frameworks!` 선언시 발생하는 빌드 실패 현상을 해결합니다.

참고 : [facebook/react-native#29633](https://github.com/facebook/react-native/issues/29633) / [comment](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)