### PR TITLE
Upgrade compileSdkVersion and targetSdkVersion to 31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,12 +24,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 31
         versionCode 1
         // get version name from package.json version
         versionName computeVersionName()


### PR DESCRIPTION
CLI에서 빌드 할 때에 react-native-channel-plugin에서 아래와 같은 에러가 발생합니다.

```
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':react-native-channel-plugin:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:/Users/rapimov/mobile_v2/node_modules/react-native-channel-plugin/android/build/intermediates/merged_res/release/values/values.xml:7104: AAPT: error: resource android:attr/lStar not found.
         

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
==============================================================================
```

androidx 버전 때문인 것 같은데, compileSdkVersion과 targetSdkVersion을 31로 올리면 빌드가 정상적으로 됩니다.
확인 부탁 드립니다.