### PR TITLE
fix: Cannot be cast from boolean to string

### DIFF
--- a/android/src/main/java/com/zoyi/channel/rn/ParseUtils.java
+++ b/android/src/main/java/com/zoyi/channel/rn/ParseUtils.java
@@ -386,11 +386,12 @@ public class ParseUtils {
     while (iterator.hasNextKey()) {
       String key = iterator.nextKey();
       ReadableType type = pushNotificationMap.getType(key);
-      String value = pushNotificationMap.getString(key);
+      if (type != ReadableType.String) continue;
 
-      if (type == ReadableType.String && value != null) {
-        pushNotification.put(key, value);
-      }
+      String value = pushNotificationMap.getString(key);
+      if (value == null) continue;
+
+      pushNotification.put(key, value);
     }
 
     return pushNotification;


### PR DESCRIPTION
```
Fatal Exception: com.facebook.react.bridge.UnexpectedNativeTypeException: Value for google.ttl cannot be cast from Double to String
at com.facebook.react.bridge.ReadableNativeMap.checkInstance(ReadableNativeMap.java:140)
at com.facebook.react.bridge.ReadableNativeMap.getNullableValue(ReadableNativeMap.java:128)
at com.facebook.react.bridge.ReadableNativeMap.getString(ReadableNativeMap.java:162)
at com.zoyi.channel.rn.ParseUtils.toPushNotification(ParseUtils.java:389)
at com.zoyi.channel.rn.RNChannelIO.isChannelPushNotification(RNChannelIO.java:154)
at java.lang.reflect.Method.invoke(Method.java)
at com.facebook.react.bridge.JavaMethodWrapper.invoke(JavaMethodWrapper.java:372)
at com.facebook.react.bridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:151)
at com.facebook.react.bridge.queue.NativeRunnable.run(NativeRunnable.java)
at android.os.Handler.handleCallback(Handler.java:942)
at android.os.Handler.dispatchMessage(Handler.java:99)
at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
at android.os.Looper.loopOnce(Looper.java:226)
at android.os.Looper.loop(Looper.java:313)
at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:226)
at java.lang.Thread.run(Thread.java:1012)
```