### PR TITLE
[Fix] remove SDK specific version from podspec

### DIFF
--- a/RNChannelIO.podspec
+++ b/RNChannelIO.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
 
   s.ios.deployment_target = '11.0'
-  
+
   s.dependency "React"
-  s.dependency "ChannelIOSDK", '~> 10'
+  s.dependency "ChannelIOSDK"
 end


### PR DESCRIPTION
ChannelIOSDK 최신 버전이 11.0.3(23.08.11 기준)이라 podfile에 latest로 설정하면 버전 차이로 pod install에서 에러가 발생해 수정 요청합니다.