### PR TITLE
안드로이드 Local Push 크래시 대응: Update ParseUtils.java

### DIFF
--- a/android/src/main/java/com/zoyi/channel/rn/ParseUtils.java
+++ b/android/src/main/java/com/zoyi/channel/rn/ParseUtils.java
@@ -470,6 +470,10 @@ public class ParseUtils {
     HashMap<String, String> pushNotification = new HashMap<>();
     ReadableMapKeySetIterator iterator = pushNotificationMap.keySetIterator();
 
+    if (pushNotificationMap == null) {
+      return pushNotification;
+    }
+
     while (iterator.hasNextKey()) {
       String key = iterator.nextKey();
       ReadableType type = pushNotificationMap.getType(key);


### PR DESCRIPTION
Expo를 사용하여 Local Push를 보낼 때, data 필드가 없는 경우에 앱이 강제 종료되어 대응 코드를 추가했습니다. 