### PR TITLE
0.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.11.10
+
+## Update
+* support android channel-io 12.14.0
+* support iOS channel-io 12.13.0
+
 # 0.11.9
 
 ## Update

--- a/RNChannelIO.podspec
+++ b/RNChannelIO.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '15.0'
   
   s.dependency "React"
-  s.dependency "ChannelIOSDK", '12.11.0'
+  s.dependency "ChannelIOSDK", '12.13.0'
 
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,5 +57,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native'
-    api 'io.channel:plugin-android:12.12.0'
+    api 'io.channel:plugin-android:12.14.0'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-channel-plugin",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "description": "react native module for channel io",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
# 0.11.10

## Update
* support android channel-io 12.14.0
* support iOS channel-io 12.13.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Android용 Channel.io SDK를 12.14.0으로, iOS용 ChannelIO SDK를 12.13.0으로 업데이트하여 최신 버전과의 호환성을 강화했습니다.
  * 패키지 버전을 0.11.10으로 상향했습니다.
  * 공용 API 변화나 동작 변경은 없습니다.

* **Documentation**
  * CHANGELOG에 0.11.10 릴리스 항목을 추가하고, Android 12.14.0 및 iOS 12.13.0 지원 내용을 명시했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->