### PR TITLE
feat: add bump.yml and release-tag.yml for SDK version automation

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,199 @@
+name: Bump RN plugin version
+
+on:
+  workflow_dispatch:
+    inputs:
+      new_rn_version:
+        description: 'New RN plugin version (e.g., 0.12.9; must be greater than current)'
+        required: true
+        type: string
+
+concurrency:
+  group: rn-bump
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    env:
+      NEW_RN: ${{ inputs.new_rn_version }}
+    steps:
+      - name: Validate semver format
+        run: |
+          if [[ ! "$NEW_RN" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::invalid semver: $NEW_RN (expected X.Y.Z)"
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Read current versions
+        id: current
+        run: |
+          CURRENT_RN=$(jq -r '.version' package.json)
+          CURRENT_ANDROID=$(grep -oE "plugin-android:[0-9]+\.[0-9]+\.[0-9]+" android/build.gradle | cut -d: -f2)
+          CURRENT_IOS=$(grep -oE "ChannelIOSDK[^']*'[0-9]+\.[0-9]+\.[0-9]+'" RNChannelIO.podspec | grep -oE "[0-9]+\.[0-9]+\.[0-9]+")
+          echo "rn=$CURRENT_RN" >> "$GITHUB_OUTPUT"
+          echo "android=$CURRENT_ANDROID" >> "$GITHUB_OUTPUT"
+          echo "ios=$CURRENT_IOS" >> "$GITHUB_OUTPUT"
+
+      - name: Check new version > current
+        env:
+          CURRENT_RN: ${{ steps.current.outputs.rn }}
+        run: |
+          HIGHEST=$(printf '%s\n' "$CURRENT_RN" "$NEW_RN" | sort -V | tail -1)
+          if [[ "$HIGHEST" != "$NEW_RN" || "$CURRENT_RN" == "$NEW_RN" ]]; then
+            echo "::error::version must be greater than current ($CURRENT_RN)"
+            exit 1
+          fi
+
+      - name: Fetch latest SDK releases
+        id: latest
+        env:
+          GH_TOKEN: ${{ secrets.SDK_READ_TOKEN }}
+        run: |
+          ANDROID_LATEST=$(gh api repos/channel-io/cht-plugin-android/releases/latest --jq '.tag_name') || {
+            echo "::error::SDK fetch failed for Android"; exit 1;
+          }
+          IOS_LATEST=$(gh api repos/channel-io/channel-plugin-ios/releases/latest --jq '.tag_name') || {
+            echo "::error::SDK fetch failed for iOS"; exit 1;
+          }
+          echo "android=$ANDROID_LATEST" >> "$GITHUB_OUTPUT"
+          echo "ios=$IOS_LATEST" >> "$GITHUB_OUTPUT"
+
+      - name: Determine what changed
+        id: changed
+        env:
+          CURRENT_ANDROID: ${{ steps.current.outputs.android }}
+          CURRENT_IOS: ${{ steps.current.outputs.ios }}
+          ANDROID_LATEST: ${{ steps.latest.outputs.android }}
+          IOS_LATEST: ${{ steps.latest.outputs.ios }}
+          CURRENT_RN: ${{ steps.current.outputs.rn }}
+        run: |
+          ANDROID_CHANGED=false
+          IOS_CHANGED=false
+          [[ "$CURRENT_ANDROID" != "$ANDROID_LATEST" ]] && ANDROID_CHANGED=true
+          [[ "$CURRENT_IOS" != "$IOS_LATEST" ]] && IOS_CHANGED=true
+          if [[ "$ANDROID_CHANGED" == "false" && "$IOS_CHANGED" == "false" && "$CURRENT_RN" == "$NEW_RN" ]]; then
+            echo "::error::nothing to bump — both SDKs at current pins and RN version unchanged"
+            exit 1
+          fi
+          echo "android=$ANDROID_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "ios=$IOS_CHANGED" >> "$GITHUB_OUTPUT"
+
+      - name: Check branch does not exist
+        run: |
+          if git ls-remote --exit-code --heads origin "auto-bump/$NEW_RN"; then
+            echo "::error::branch auto-bump/$NEW_RN already exists on origin — delete it or pick a different version"
+            exit 1
+          fi
+
+      - name: Edit files
+        env:
+          ANDROID_LATEST: ${{ steps.latest.outputs.android }}
+          IOS_LATEST: ${{ steps.latest.outputs.ios }}
+        run: |
+          jq --arg v "$NEW_RN" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+          sed -i -E "s/(plugin-android:)[0-9]+\.[0-9]+\.[0-9]+/\1${ANDROID_LATEST}/" android/build.gradle
+          sed -i -E "s/(s\.dependency[[:space:]]+\"ChannelIOSDK\",[[:space:]]*')[0-9]+\.[0-9]+\.[0-9]+(')/\1${IOS_LATEST}\2/" RNChannelIO.podspec
+          sed -i -E "s/(s\.version[[:space:]]*=[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\")/\1${NEW_RN}\2/" RNChannelIO.podspec
+
+      - name: Prepend CHANGELOG entry
+        env:
+          ANDROID_LATEST: ${{ steps.latest.outputs.android }}
+          IOS_LATEST: ${{ steps.latest.outputs.ios }}
+          ANDROID_CHANGED: ${{ steps.changed.outputs.android }}
+          IOS_CHANGED: ${{ steps.changed.outputs.ios }}
+        run: |
+          BULLETS=""
+          [[ "$ANDROID_CHANGED" == "true" ]] && BULLETS+="* support android channel-io ${ANDROID_LATEST}"$'\n'
+          [[ "$IOS_CHANGED" == "true" ]] && BULLETS+="* support iOS channel-io ${IOS_LATEST}"$'\n'
+          {
+            printf '# %s\n\n## Update\n%s\n' "$NEW_RN" "$BULLETS"
+            cat CHANGELOG.md
+          } > CHANGELOG.md.new
+          mv CHANGELOG.md.new CHANGELOG.md
+
+      - name: Commit on new branch
+        env:
+          ANDROID_LATEST: ${{ steps.latest.outputs.android }}
+          IOS_LATEST: ${{ steps.latest.outputs.ios }}
+        run: |
+          BRANCH="auto-bump/$NEW_RN"
+          git checkout -b "$BRANCH"
+          git add package.json android/build.gradle RNChannelIO.podspec CHANGELOG.md
+          git commit -m "chore: bump to ${NEW_RN} (android ${ANDROID_LATEST}, iOS ${IOS_LATEST})"
+          git push origin "$BRANCH"
+
+      - name: Build PR body
+        id: body
+        env:
+          CURRENT_RN: ${{ steps.current.outputs.rn }}
+          CURRENT_ANDROID: ${{ steps.current.outputs.android }}
+          CURRENT_IOS: ${{ steps.current.outputs.ios }}
+          ANDROID_LATEST: ${{ steps.latest.outputs.android }}
+          IOS_LATEST: ${{ steps.latest.outputs.ios }}
+          ANDROID_CHANGED: ${{ steps.changed.outputs.android }}
+          IOS_CHANGED: ${{ steps.changed.outputs.ios }}
+        run: |
+          if [[ "$ANDROID_CHANGED" == "true" ]]; then
+            ANDROID_ROW="| Android SDK | ${CURRENT_ANDROID} | **${ANDROID_LATEST}** ([release notes](https://github.com/channel-io/cht-plugin-android/releases/tag/${ANDROID_LATEST})) |"
+          else
+            ANDROID_ROW="| Android SDK | ${CURRENT_ANDROID} | *unchanged* |"
+          fi
+          if [[ "$IOS_CHANGED" == "true" ]]; then
+            IOS_ROW="| iOS SDK | ${CURRENT_IOS} | **${IOS_LATEST}** ([release notes](https://github.com/channel-io/channel-plugin-ios/releases/tag/${IOS_LATEST})) |"
+          else
+            IOS_ROW="| iOS SDK | ${CURRENT_IOS} | *unchanged* |"
+          fi
+          {
+            echo 'body<<PR_BODY_EOF'
+            printf '## Bump Summary\n\n'
+            printf '| Component | From | To |\n|---|---|---|\n'
+            printf '| RN plugin | %s | **%s** |\n' "$CURRENT_RN" "$NEW_RN"
+            echo "$ANDROID_ROW"
+            echo "$IOS_ROW"
+            printf '\n## Review checklist\n\n'
+            printf -- '- [ ] iOS SDK CHANGELOG confirmed — no breaking/deprecation affecting bridge\n'
+            printf -- '- [ ] Android SDK CHANGELOG confirmed — no breaking/deprecation affecting bridge\n'
+            printf -- '- [ ] `index.ts` bridge signatures still valid\n'
+            printf -- '- [ ] Native bridge (`ios/*.m`, `android/src/`) changes unnecessary\n\n'
+            printf 'If bridging changes are needed, commit directly to this branch.\n'
+            printf 'Merging to master triggers `release-tag.yml` → tag + Release → `npm publish`.\n\n'
+            printf -- '---\n🤖 Auto-generated by `bump.yml`\n'
+            echo 'PR_BODY_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ steps.body.outputs.body }}
+          ANDROID_CHANGED: ${{ steps.changed.outputs.android }}
+          IOS_CHANGED: ${{ steps.changed.outputs.ios }}
+          ANDROID_LATEST: ${{ steps.latest.outputs.android }}
+          IOS_LATEST: ${{ steps.latest.outputs.ios }}
+        run: |
+          PARTS=""
+          [[ "$ANDROID_CHANGED" == "true" ]] && PARTS+="android ${ANDROID_LATEST}"
+          if [[ "$IOS_CHANGED" == "true" ]]; then
+            [[ -n "$PARTS" ]] && PARTS+=", "
+            PARTS+="iOS ${IOS_LATEST}"
+          fi
+          TITLE="Bump to ${NEW_RN}"
+          [[ -n "$PARTS" ]] && TITLE+=" (${PARTS})"
+          gh pr create \
+            --base master \
+            --head "auto-bump/${NEW_RN}" \
+            --title "$TITLE" \
+            --body "$PR_BODY"

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,98 @@
+name: Release tag + back-merge
+
+on:
+  push:
+    branches: [master]
+
+concurrency:
+  group: release-tag
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Read package.json version
+        id: ver
+        run: echo "version=$(jq -r '.version' package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Check tag existence
+        id: tag
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          if git rev-parse "refs/tags/$V" >/dev/null 2>&1; then
+            echo "::notice::tag $V already exists — skipping release"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract CHANGELOG section
+        if: steps.tag.outputs.exists == 'false'
+        id: changelog
+        env:
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          SECTION=$(awk -v ver="$V" '
+            /^# [0-9]+\.[0-9]+\.[0-9]+/ {
+              if (printing) exit
+              if ($2 == ver) { printing = 1; next }
+            }
+            printing
+          ' CHANGELOG.md)
+          if [[ -z "$SECTION" ]]; then
+            echo "::warning::CHANGELOG section for $V is empty — Release will have empty body"
+          fi
+          {
+            echo 'body<<CHANGELOG_EOF'
+            echo "$SECTION"
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create tag + Release
+        if: steps.tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_CREATE_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+          BODY: ${{ steps.changelog.outputs.body }}
+        run: |
+          gh release create "$V" \
+            --target "${{ github.sha }}" \
+            --title "$V" \
+            --notes "$BODY"
+
+      - name: Open back-merge PR
+        if: steps.tag.outputs.exists == 'false'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          V: ${{ steps.ver.outputs.version }}
+        run: |
+          BRANCH="backmerge/$V"
+          git checkout -b "$BRANCH"
+          if ! git push origin "$BRANCH"; then
+            echo "::warning::Back-merge branch push failed for $V; develop is now behind master"
+            exit 0
+          fi
+          if ! gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore: back-merge $V to develop" \
+            --body "Auto-generated after releasing $V to master. Merging keeps develop in sync." \
+            --label "auto-merge"; then
+            echo "::warning::Back-merge PR creation failed for $V; develop is now behind master"
+          fi


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows to semi-automate RN plugin version bumps driven by iOS/Android SDK releases.

### Workflows added
- `.github/workflows/bump.yml` — `workflow_dispatch` with `new_rn_version` input. Auto-discovers latest iOS/Android SDK releases via `gh api`, edits `package.json` / `android/build.gradle` / `RNChannelIO.podspec` (fixes the long-stale `s.version = "0.6.0"`) / `CHANGELOG.md`, opens a PR to master.
- `.github/workflows/release-tag.yml` — on push to master, idempotently creates a git tag + GitHub Release (using `RELEASE_CREATE_TOKEN` PAT so the existing `ci.yml` actually fires); opens a back-merge PR from master to develop.

The existing `ci.yml` (npm publish on release creation) is **unchanged**.

### Human loop per release (once this lands)
1. SDK release → notification in team chat (separate PRs in `cht-plugin-android` + `channel-plugin-ios` to be opened).
2. Click link → run `bump.yml` in Actions UI with the new RN version.
3. Review the auto-generated PR (add bridging commits if SDK API changed).
4. Merge. `npm publish` runs without further manual action.

### Critical design note
`release-tag.yml` uses a dedicated `RELEASE_CREATE_TOKEN` PAT for `gh release create` (NOT the default `GITHUB_TOKEN`). GitHub Actions suppresses downstream workflow triggers for `GITHUB_TOKEN`-originated events, so using the default would silently break the `ci.yml` chain.

## Required before merge
- [ ] Repo secret `SDK_READ_TOKEN` — fine-grained PAT, `Contents: Read` on `cht-plugin-android` + `channel-plugin-ios`
- [ ] Repo secret `RELEASE_CREATE_TOKEN` — fine-grained PAT, `Contents: Write` on this repo
- [ ] Label `auto-merge` exists
- [ ] Settings → General → Allow auto-merge enabled
- [ ] Settings → Actions → Workflow permissions: read + write

## Test plan
- [ ] bump.yml: sed/jq patterns verified locally against current files (done during implementation — matches current `android/build.gradle`, `RNChannelIO.podspec`, `package.json`)
- [ ] release-tag.yml: awk CHANGELOG extractor verified against current `CHANGELOG.md` (done during implementation)
- [ ] Post-merge shakedown:
  - Dispatch with invalid semver → expect validation error, no side effects
  - Dispatch with version ≤ current → expect validation error
  - Dispatch with throwaway version (e.g., `99.99.99`) → expect PR opened with all 4 file edits correct; close/delete PR without merging
  - Confirm `release-tag.yml` ran on this PR's own merge commit and took the skip path (current `0.12.8` already has a tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 자동화된 버전 업데이트 워크플로우를 추가하여 React Native 및 모바일 SDK 버전 관리를 간소화했습니다.
  * 자동화된 릴리스 생성 및 브랜치 병합 워크플로우를 추가하여 배포 프로세스를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->