### PR TITLE
[Fix] Android URL 클릭 무반응 수정 (구독자 없을 때 네이티브 처리 + activity null 폴백)

### DIFF
--- a/android/src/main/java/com/zoyi/channel/rn/RNChannelIO.java
+++ b/android/src/main/java/com/zoyi/channel/rn/RNChannelIO.java
@@ -27,6 +27,7 @@ public class RNChannelIO extends ReactContextBaseJavaModule implements ChannelPl
   private ReactContext reactContext;
 
   private boolean hasPushNotificationClickSubscriber = false;
+  private boolean hasUrlClickSubscriber = false;
 
   public RNChannelIO(ReactApplicationContext reactContext) {
     super(reactContext);
@@ -249,8 +250,15 @@ public class RNChannelIO extends ReactContextBaseJavaModule implements ChannelPl
     );
   }
 
+  @ReactMethod
+  public void notifyUrlClickSubscriberExistence(boolean hasUrlClickSubscriber) {
+    this.hasUrlClickSubscriber = hasUrlClickSubscriber;
+  }
+
   @Override
   public boolean onUrlClicked(String url) {
+    if (!hasUrlClickSubscriber) { return false; }
+
     Utils.sendEvent(reactContext, Const.EVENT_ON_PRE_URL_CLICKED, ParseUtils.createSingleMap(Const.KEY_EVENT_URL, url));
     return true;
   }
@@ -287,10 +295,15 @@ public class RNChannelIO extends ReactContextBaseJavaModule implements ChannelPl
 
   @ReactMethod
   public void handleUrlClicked(@Nullable String url) {
-    Activity activity = getCurrentActivity();
+    if (url == null) { return; }
 
-    if (activity != null && url != null) {
+    Activity activity = getCurrentActivity();
+    if (activity != null) {
       IntentUtils.setUrl(activity, url).startActivity();
+    } else if (reactContext != null) {
+      IntentUtils.setUrl(reactContext.getApplicationContext(), url)
+          .setFlag(Intent.FLAG_ACTIVITY_NEW_TASK)
+          .startActivity();
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -160,6 +160,7 @@ interface ChannelModuleType {
   setAppearance: (appearance: Appearance) => void;
   hidePopup: () => void;
   handleUrlClicked: (url: string) => void;
+  notifyUrlClickSubscriberExistence: (exists: boolean) => void;
   notifyPushNotificationClickSubscriberExistence: (exists: boolean) => void;
   performDefaultPushNotificationClickAction: (userId: string, chatId: string) => void;
 }
@@ -469,10 +470,17 @@ export const ChannelIO: RNChannelIO = {
         }
         cb(data.url, next);
       });
+
+      if (Platform.OS === 'android') {
+        ChannelModule.notifyUrlClickSubscriberExistence(true);
+      }
     } else {
+      if (Platform.OS === 'android') {
+        ChannelModule.notifyUrlClickSubscriberExistence(false);
+      }
       replaceSubscriber(ChannelModule.Event.ON_URL_CLICKED, null);
     }
-  }, 
+  },
 
   /**
    * Event listener that triggers when guest profile is updated


### PR DESCRIPTION
## 문제

RN New Architecture(bridgeless) Android에서 상담창(showMessenger) 내 HTTPS 링크 클릭이 **에러 없이 무반응**하는 사례가 보고되었습니다. iOS는 정상입니다.

Android의 링크 클릭은 `Native → JS → Native` 왕복에 의존합니다.

```
onUrlClicked(네이티브) → PRE_URL_CLICKED emit → JS 리스너 → handleUrlClicked(네이티브) → ChWebViewActivity
```

`onUrlClicked`가 JS 구독자 유무와 무관하게 **무조건 `true`를 반환**해 SDK의 기본 열기를 차단하기 때문에, 이 왕복 중 어느 지점이든 끊기면 아무도 링크를 열지 않는 상태가 됩니다. 두 지점이 침묵 실패합니다.

1. **Native→JS emit 유실**: bridgeless에서 React 인스턴스가 준비되지 않은 시점에는 emit이 soft exception으로만 남고 유실될 수 있습니다.
2. **`getCurrentActivity()` null**: 메신저 Activity가 React Activity 위에 뜬 상태에서 뒤의 React Activity가 파괴되면 `handleUrlClicked`의 `getCurrentActivity()`가 null이 되어 클릭이 조용히 무시됩니다.

iOS는 `handleUrlClicked`가 activity 없이 바로 브라우저를 열기 때문에 같은 설계에서도 증상이 없습니다.

이미 `onPushNotificationClicked`는 동일한 문제를 "JS 구독자 존재를 네이티브에 통지 → 구독자 없으면 `false` 반환" 패턴으로 해결하고 있습니다. URL 경로에만 이 패턴이 빠져 있었습니다.

## 변경

**① 구독자 없으면 네이티브에서 종결** (push 패턴과 동일)
- `notifyUrlClickSubscriberExistence(boolean)` 추가. JS의 `onUrlClicked` 등록/해제 시 호출(Android 한정).
- `onUrlClicked`는 구독자가 없으면 emit 없이 `false`를 반환해 SDK가 네이티브에서 직접 URL을 엽니다. `onUrlClicked`를 사용하지 않는 대다수 앱은 JS 왕복 자체가 사라집니다.

**② activity null 폴백**
- `handleUrlClicked`는 기존과 동일하게 `getCurrentActivity()`를 우선 사용하고, **null인 경우에만** `reactContext.getApplicationContext()` + `FLAG_ACTIVITY_NEW_TASK`로 폴백합니다. activity가 있을 때의 기존 동작(화면 전환 애니메이션 포함)은 그대로 유지되며, activity null로 인한 침묵 실패만 제거됩니다.

iOS는 정상 동작하므로 변경하지 않았습니다.

## 검증

실기기(Galaxy S9, Android 10) · RN 0.81.6 · New Architecture ON에서 확인:

| 시나리오 | 결과 |
|---|---|
| 구독자 OFF | ✅ SDK가 네이티브에서 직접 링크 오픈, JS 이벤트 미발생(이중 오픈 없음) |
| 구독자 ON | ✅ JS 콜백 수신(`last url event` 갱신) 후 `next()` → 링크 오픈, 백스택 정상 |
| 회귀 | ✅ boot/메신저/라운지/채팅 진입 정상 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * Android에서 URL 클릭 이벤트 처리 방식을 구독 여부에 따라 제어하도록 개선했습니다.
  * URL 클릭 사전 이벤트는 실제로 구독자가 있을 때만 전달되도록 변경됐습니다.
  * URL이 유효하지 않거나 현재 화면(Activity)이 없는 경우에도 불필요한 동작 없이 안정적으로 처리됩니다.
  * 앱 컨텍스트 기반 실행과 적절한 설정으로 URL 열기 안정성이 향상됐습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->