### PR TITLE
0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.13.1
+
+## Bug Fixes
+* Android - Fixed an issue where clicking a URL in the messenger did nothing.
+
 # 0.12.8
 
 ## Update

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-channel-plugin",
-  "version": "0.12.8",
+  "version": "0.13.1",
   "description": "react native module for channel io",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
0.13.1 패치 버전업입니다.

## 포함 변경
- #204 Android URL 클릭 무반응 수정 (구독자 없을 때 네이티브 처리 + activity null 시 앱 컨텍스트 폴백)

## 버전업 내역
- `package.json`: 0.13.1
- `CHANGELOG.md`: 0.13.1 `## Bug Fixes` 블록 추가

네이티브 SDK 버전을 올리지 않는 버그픽스라 `podspec` / `build.gradle`의 SDK 라인은 변경하지 않았습니다.

## 참고
이 브랜치는 develop(현재 0.12.8) 기준으로 만들어졌습니다. master는 이미 0.13.0이 릴리즈되어 있으나 develop에 아직 역머지되지 않은 상태라, develop↔master 정합은 별도로 처리가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * Android에서 메신저 내 URL을 클릭해도 동작하지 않던 문제를 해결했습니다.

* **기타**
  * 앱 버전을 0.13.1로 업데이트했습니다.
  * 변경 사항을 변경 로그에 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->